### PR TITLE
LockSettingsService: Support for separate clear key api

### DIFF
--- a/core/java/android/os/storage/IStorageManager.aidl
+++ b/core/java/android/os/storage/IStorageManager.aidl
@@ -187,4 +187,5 @@ interface IStorageManager {
     void allocateBytes(String volumeUuid, long bytes, int flags, String callingPackage) = 78;
     void runIdleMaintenance() = 79;
     void abortIdleMaintenance() = 80;
+    void clearUserKeyAuth(int userId, int serialNumber, in byte[] token, in byte[] secret) = 81;
 }

--- a/services/core/java/com/android/server/StorageManagerService.java
+++ b/services/core/java/com/android/server/StorageManagerService.java
@@ -2524,6 +2524,24 @@ class StorageManagerService extends IStorageManager.Stub
     }
 
     /*
+     * Clear disk encryption key bound to the associated token / secret pair. Removing the user
+     * binding of the Disk encryption key is done in two phases: first, this call will retrieve
+     * the disk encryption key using the provided token / secret pair and store it by
+     * encrypting it with a keymaster key not bound to the user, then fixateNewestUserKeyAuth
+     * is called to delete all other bindings of the disk encryption key.
+     */
+    @Override
+    public void clearUserKeyAuth(int userId, int serialNumber, byte[] token, byte[] secret) {
+        enforcePermission(android.Manifest.permission.STORAGE_INTERNAL);
+
+        try {
+            mVold.clearUserKeyAuth(userId, serialNumber, encodeBytes(token), encodeBytes(secret));
+        } catch (Exception e) {
+            Slog.wtf(TAG, e);
+        }
+    }
+
+    /*
      * Delete all disk encryption token/secret pairs except the most recently added one
      */
     @Override

--- a/services/core/java/com/android/server/locksettings/LockSettingsService.java
+++ b/services/core/java/com/android/server/locksettings/LockSettingsService.java
@@ -1570,6 +1570,18 @@ public class LockSettingsService extends ILockSettings.Stub {
         addUserKeyAuth(userId, null, null);
     }
 
+    private void clearUserKeyAuth(int userId, byte[] token, byte[] secret) throws RemoteException {
+        if (DEBUG) Slog.d(TAG, "clearUserKeyProtection user=" + userId);
+        final UserInfo userInfo = mUserManager.getUserInfo(userId);
+        final IStorageManager storageManager = mInjector.getStorageManager();
+        final long callingId = Binder.clearCallingIdentity();
+        try {
+            storageManager.clearUserKeyAuth(userId, userInfo.serialNumber, token, secret);
+        } finally {
+            Binder.restoreCallingIdentity(callingId);
+        }
+    }
+
     private static byte[] secretFromCredential(String credential) throws RemoteException {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-512");
@@ -2520,7 +2532,7 @@ public class LockSettingsService extends ILockSettings.Stub {
             getGateKeeperService().clearSecureUserId(userId);
             // Clear key from vold so ActivityManager can just unlock the user with empty secret
             // during boot.
-            clearUserKeyProtection(userId);
+            clearUserKeyAuth(userId, null, auth.deriveDiskEncryptionKey());
             fixateNewestUserKeyAuth(userId);
             setKeystorePassword(null, userId);
         }


### PR DESCRIPTION
With the new key management changes for FBE, the keys
are not present in the clear in vold. So, while clearing a pin,
we cannot use the present method to rebound the key to keymaster.

We need to provide the old secret so as to retrieve the key
and then bind it with keymaster.

CRs-Fixed: 2288316

Change-Id: I1dd707513a3d45b62b925fa7bba15babdba9bd1c